### PR TITLE
Add some uninstallable operators to the deny list

### DIFF
--- a/curator.py
+++ b/curator.py
@@ -22,7 +22,10 @@ WHITELISTED_PACKAGES = [
 ]
 
 BLACKLISTED_PACKAGES = [
-    "certified-operators/mongodb-enterprise"
+    "certified-operators/mongodb-enterprise",
+    "community-operators/etcd",
+    "community-operators/federation",
+    "community-operators/syndesis"
 ]
 
 def _url(path):


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1984

Remove community operators that cannot be installed: etcd, federation, syndesis