### PR TITLE
SREP-2215: Summarize results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+certified-operators/
+community-operators/
+redhat-operators/

--- a/curator.py
+++ b/curator.py
@@ -135,7 +135,7 @@ def validate_bundle(package, version):
         except KeyError:
             # Cannot perform tests; skip further processing
             logging.warn("[FAIL] Can't validate {} version {}: 'bundle.yaml' not present in package".format(package, version))
-            tests["bundle.yaml should be present"] = False
+            tests["bundle.yaml must be present"] = False
             return False, tests
         by = yaml.safe_load(bf.read())
         csvs = yaml.safe_load(by['data']['clusterServiceVersions'])

--- a/curator.py
+++ b/curator.py
@@ -141,7 +141,8 @@ def validate_bundle(package, version):
         csvs = yaml.safe_load(by['data']['clusterServiceVersions'])
         for csv in csvs:
             # Cluster Permissions aren't allowed
-            tests["should not require cluster permissions"] = True
+            cpKey = "CSV must not include clusterPermissions"
+            tests[cpKey] = True
             if csv['spec']['install']['spec'].has_key('clusterPermissions'):
                 logging.info("[FAIL] {} version {} requires clusterPermissions".format(package, version))
                 tests["should not require cluster permissions"] = False

--- a/curator.py
+++ b/curator.py
@@ -131,7 +131,7 @@ def validate_bundle(package, version):
     with tarfile.open("{}/{}/{}.tar.gz".format(package, version, shortname)) as t:
         try:
             bf = t.extractfile('bundle.yaml')
-            tests["bundle.yaml should be present"] = True
+            tests["bundle.yaml must be present"] = True
         except KeyError:
             # Cannot perform tests; skip further processing
             logging.warn("[FAIL] Can't validate {} version {}: 'bundle.yaml' not present in package".format(package, version))

--- a/curator.py
+++ b/curator.py
@@ -158,7 +158,8 @@ def validate_bundle(package, version):
                             logging.info("[FAIL] {} version {} requires security context constraints".format(package, version))
                             tests["should not require security context constraints"] = False
             # installMode == MultiNamespace is not allowed
-            tests["should not support multi-namespace install mode"] = True
+            multiNsKey = "CSV must not require MultiNamespace installMode"
+            tests[multiNsKey] = True
             for im in csv['spec']['installModes']:
                 if im['type'] == "MultiNamespace" and im['supported'] is True:
                     logging.info("[FAIL] {} version {} supports multi-namespace install mode".format(package, version))

--- a/curator.py
+++ b/curator.py
@@ -156,7 +156,7 @@ def validate_bundle(package, version):
                             "use" in i['verbs'] and
                             "securitycontextconstraints" in i['resources']):
                             logging.info("[FAIL] {} version {} requires security context constraints".format(package, version))
-                            tests["should not require security context constraints"] = False
+                            tests[sccKey] = False
             # installMode == MultiNamespace is not allowed
             multiNsKey = "CSV must not require MultiNamespace installMode"
             tests[multiNsKey] = True

--- a/curator.py
+++ b/curator.py
@@ -163,7 +163,7 @@ def validate_bundle(package, version):
             for im in csv['spec']['installModes']:
                 if im['type'] == "MultiNamespace" and im['supported'] is True:
                     logging.info("[FAIL] {} version {} supports multi-namespace install mode".format(package, version))
-                    tests["should not support multi-namespace install mode"] = False
+                    tests[multiNsKey] = False
 
 
     # If all of the values for dict "tests" are True, return True

--- a/curator.py
+++ b/curator.py
@@ -125,7 +125,7 @@ def validate_bundle(package, version):
     # Any package in our blacklist is invalid; skip further processing
     if package in BLACKLISTED_PACKAGES:
         logging.info("[FAIL] {} version {} is blacklisted".format(package, version))
-        tests["should not be blacklisted"] = False
+        tests["is in denied list"] = False
         return False, tests
     
     with tarfile.open("{}/{}/{}.tar.gz".format(package, version, shortname)) as t:

--- a/curator.py
+++ b/curator.py
@@ -147,7 +147,8 @@ def validate_bundle(package, version):
                 logging.info("[FAIL] {} version {} requires clusterPermissions".format(package, version))
                 tests["should not require cluster permissions"] = False
             # Using SCCs isn't allowed
-            tests["should not require security context constraints"] = True
+            sccKey = "CSV must not grant SecurityContextConstraints permissions"
+            tests[sccKey] = True
             if csv['spec']['install']['spec'].has_key('permissions'):
                 for rules in csv['spec']['install']['spec']['permissions']:
                     for i in rules['rules']:

--- a/curator.py
+++ b/curator.py
@@ -145,7 +145,7 @@ def validate_bundle(package, version):
             tests[cpKey] = True
             if csv['spec']['install']['spec'].has_key('clusterPermissions'):
                 logging.info("[FAIL] {} version {} requires clusterPermissions".format(package, version))
-                tests["should not require cluster permissions"] = False
+                tests[cpKey] = False
             # Using SCCs isn't allowed
             sccKey = "CSV must not grant SecurityContextConstraints permissions"
             tests[sccKey] = True

--- a/curator.py
+++ b/curator.py
@@ -119,7 +119,7 @@ def validate_bundle(package, version):
     # Any package in our whitelist is valid, regardless of other heuristics
     if package in WHITELISTED_PACKAGES:
         logging.info("[PASS] {} version {} is whitelisted".format(package, version))
-        tests["is whitelisted"] = True
+        tests["is in allowed list"] = True
         return True, tests
 
     # Any package in our blacklist is invalid; skip further processing


### PR DESCRIPTION
This PR addresses SREP-2215:

At the end of the operator-curator job execution, generate a summary of the reasons to reject/approve operators.

-  Output a summary at the job execution with a list of the reasons for each operator to be rejected by curation
-  List all possible reasons, not just the first one that triggered rejection
-  Display it in the Jenkins job output

*** 

Logging during run increased to allow investigation when necessary.
Summary is printed at end of run.
Summary printed to stdout; will be visible in Jenkins log
Overall failures aggregated for each operator.

Additional flags added for local development:
-  --cache; skips downloading package...uses local cache
-  --skip-push; skips pushing validated packages to Quay.io

Example of summary at end of run:

```
Validation Summary
------------------
[FAIL] community-operators/cert-utils-operator version 0.0.1
    [PASS] should not require security context constraints
    [PASS] bundle.yaml should be present
    [PASS] should not support multi-namespace install mode
    [FAIL] should not require cluster permissions

[FAIL] community-operators/cert-utils-operator version 0.0.3
    [FAIL] bundle.yaml should be present

[PASS] community-operators/atlasmap-operator version 0.0.1
    [PASS] should not require security context constraints
    [PASS] bundle.yaml should be present
    [PASS] should not support multi-namespace install mode
    [PASS] should not require cluster permissions
```