### PR TITLE
Adding tests and lint fixes, refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,4 @@ RUN pylint -d W0621 \
 RUN python3 -m unittest test_curator.py
 
 ENTRYPOINT ["/app/curator.py"]
-CMD ["--skip-push"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+LABEL maintainer "Red Hat OpenShift Dedicated SRE Team"
+
+RUN microdnf install -y python3 python3-pip
+RUN pip3 install pylint
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY . ./
+
+RUN pip3 install -r requirements.txt
+
+# W1202: False positive with python3 f-strings
+# W0511: Ignore TODO notes
+# W0707: Temporarily ignore bare exception warning
+# R0911, R0913, R0914, $0915: Temporarily ignore warnings of
+# function with too many statements, arguments, returns and variables
+RUN pylint -d W0621 \
+           -d W0707 \
+           -d W1202 \
+           -d W1203 \
+           -d C0103 \
+           -d C0301 \
+           -d R0911 \
+           -d R0913 \
+           -d R0914 \
+           -d R0915 \
+           curator.py
+
+RUN python3 -m unittest test_curator.py
+
+ENTRYPOINT ["/app/curator.py"]
+CMD ["--skip-push"]
+

--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ The curator is a single python script that requires:
 
 ## Credentials
 
-In order to use this script, you'll need basic auth credentials for the Quay CNR API as well as an oauth token the Quay repository API. The basic auth token is required to push packages to the app registry, and the oauth token is required to make new packages publicly visible. 
+In order to use this script, you'll need basic auth credentials for the Quay CNR API as well as an oauth token the Quay repository API. The basic auth token is required to push packages to the app registry, and the oauth token is required to make new packages publicly visible.
 
 ### Getting a basic auth token
 
 The included script 'get-quay-token' will prompt for your Quay.io username and password and will return a basic auth token in this format:
 
 {"token":"basic abcdefghi123456=="}
-
 
 ### Getting an oauth token
 
@@ -31,7 +30,7 @@ Copy down the generated access token
 
 Access Token: ZaaaAAAinsertvalidoauthtokenhereAAAaaaaz
 
-This token will work across all organizations that your user has access to. 
+This token will work across all organizations that your user has access to.
 
 ## Usage
 
@@ -63,5 +62,26 @@ Operators that are deemed valid are then uploaded to their curated registry. Cur
 * curated-certified-operators
 * curated-community-operators
 
+## Running Unit Tests By Hand
 
+Running unit tests by hand is just a matter of running:
 
+```sh
+# Python3 if python --version is not 3
+python3 -m unittest test_curator.py
+
+# otherwise:
+python -m unittest test_curator.py
+```
+
+## Linting
+
+Python linting can be done using Pylint.  Note that this isn't _currently_ completely passing the linter tests.
+
+```sh
+# Install pylint if it's not already
+pip3 install --user pylint
+
+pylint curator.py
+pylint test_curator.py
+```

--- a/curator.py
+++ b/curator.py
@@ -133,8 +133,6 @@ def get_package_release(release, use_cache):
     try:
         with open(outfile, 'wb') as f:
             shutil.copyfileobj(r.raw, f)
-    except:
-        raise
     finally:
         del r
 
@@ -177,8 +175,8 @@ def extract_bundle_from_tar_file(operator_tarfile):
             result = False
         else:
             result = True
-        finally:
-            return bundle_file, test_name, result
+
+    return bundle_file, test_name, result
 
 
 def load_yaml_from_bundle_object(bundle_yaml_obj):
@@ -195,8 +193,8 @@ def load_yaml_from_bundle_object(bundle_yaml_obj):
         result = False
     else:
         result = True
-    finally:
-        return bundle_yaml, test_name, result
+
+    return bundle_yaml, test_name, result
 
 
 def get_entry_from_bundle(bundle_yaml, entry):
@@ -213,8 +211,8 @@ def get_entry_from_bundle(bundle_yaml, entry):
         result = False
     else:
         result = True
-    finally:
-        return data, test_name, result
+
+    return data, test_name, result
 
 
 def validate_csv(package, version, csv):
@@ -341,8 +339,8 @@ def validate_bundle(release):
         return False, tests
 
     # Retrieve the package list from the bundle
-    packages, name, result = get_entry_from_bundle(bundle_yaml,
-        'packages')
+    packages, name, result = get_entry_from_bundle(
+        bundle_yaml, 'packages')
     tests[name] = result
     logging.info(f"{'[PASS]' if result else '[FAIL]'} {package} (all versions) {name}")
 
@@ -351,8 +349,8 @@ def validate_bundle(release):
         return False, tests
 
     # Retrieve the csv list from the bundle
-    csvs, name, result = get_entry_from_bundle(bundle_yaml,
-        'clusterServiceVersions')
+    csvs, name, result = get_entry_from_bundle(
+        bundle_yaml, 'clusterServiceVersions')
     tests[name] = result
     logging.info(f"{'[PASS]' if result else '[FAIL]'} {package} (all versions) {name}")
 
@@ -457,7 +455,8 @@ def push_package(package, version, target_namespace, oauth_token, basic_token, s
         return
 
     # Don't try to push if the specific package version is already present in our target namespace
-    target_releases = get_package_release(f"{target_namespace}/{shortname}")
+    target_releases = get_package_release(
+        f"{target_namespace}/{shortname}", use_cache=True)
     if version in target_releases.keys():
         logging.info(f"Version {version} of {shortname} is already present in {target_namespace} namespace. Skipping...")
         return
@@ -493,7 +492,7 @@ def push_package(package, version, target_namespace, oauth_token, basic_token, s
 def summarize(summary, out=sys.stdout):
     """Summarize prints a summary of results for human readability."""
 
-    if not type(summary) == list:
+    if not isinstance(summary, list):
         raise TypeError()
     if not summary:
         raise IndexError()
@@ -526,22 +525,26 @@ def summarize(summary, out=sys.stdout):
 if __name__ == "__main__":
 
     PARSER = argparse.ArgumentParser(
-        description="""
-            A tool for curating application registry for use with OSDv4
-        """)
-    PARSER.add_argument('--app-token', action="store",
+        description=("""A tool for curating application registry for
+            use with OSDv4."""))
+    PARSER.add_argument(
+        '--app-token', action="store",
         dest="basic_token", type=str,
         help="Basic auth token for use with Quay's CNR API")
-    PARSER.add_argument('--oauth-token', action="store",
+    PARSER.add_argument(
+        '--oauth-token', action="store",
         dest="oauth_token", type=str,
         help="Oauth token for use with Quay's repository API")
-    PARSER.add_argument('--cache', action="store_true",
-        default=False, dest="use_cache", type=str,
+    PARSER.add_argument(
+        '--cache', action="store_true",
+        default=False, dest="use_cache",
         help="Use local cache of operator packages")
-    PARSER.add_argument('--skip-push', action="store_true",
-        default=False, dest="skip_push", type=str,
+    PARSER.add_argument(
+        '--skip-push', action="store_true",
+        default=False, dest="skip_push",
         help="Skip pushing validated packages to Quay.io")
-    PARSER.add_argument('--log-level', action="store",
+    PARSER.add_argument(
+        '--log-level', action="store",
         default='info', dest="log_level", type=str,
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
         help="Set verbosity of logs printed to STDOUT.")

--- a/curator.py
+++ b/curator.py
@@ -302,19 +302,20 @@ def validate_bundle(release):
 
     # Any package in our allow list is valid, regardless of other heuristics
     name, result = check_package_in_allow_list(package)
-    tests[name] = result
 
     if result:
         logging.info(f"[PASS] {package} (all versions) {name}")
+        # ONLY return test result if it is in the list
+        tests[name] = result
         return True, tests
-
 
     # Any package in our deny is invalid; skip further processing
     name, result = check_package_in_deny_list(package)
-    tests[name] = result
 
     if result:
         logging.info(f"[FAIL] {package} (all versions) {name}")
+        # ONLY return test result if it is in the list
+        tests[name] = result
         return False, tests
 
     # Extract the bundle.yaml file
@@ -327,7 +328,6 @@ def validate_bundle(release):
     # If extracting the bundle fails, no further processing is possible
     if not result:
         return False, tests
-
 
     # Load the yaml from the bundle object to a variable
     bundle_yaml, name, result = load_yaml_from_bundle_object(bundle_yaml_object)

--- a/curator.py
+++ b/curator.py
@@ -496,11 +496,12 @@ def push_package(release, target_namespace, oauth_token, basic_token):
 
     shortname = _pkg_shortname(package)
 
-    with open(f"{package}/{version}/{shortname}.tar.gz") as f:
+    with open(f"{package}/{version}/{shortname}.tar.gz", 'rb') as f:
         encoded_bundle = base64.b64encode(f.read())
+        encoded_bundle_str = encoded_bundle.decode()
 
     payload = {
-        "blob": encoded_bundle,
+        "blob": encoded_bundle_str,
         "release": version,
         "media_type": "helm"
     }

--- a/curator.py
+++ b/curator.py
@@ -535,6 +535,7 @@ def summarize(summary, out=sys.stdout):
     report = []
 
     passing_count = len([i for i in summary if {key:value for (key, value) in i.items() if value["pass"]}])
+    skipped_count = len([i for i in summary if {key:value for (key, value) in i.items() if value["skipped"]}])
     for i in summary:
         for operator, info in i.items():
             operator_result = "[PASS]" if info["pass"] else "[FAIL]"
@@ -547,12 +548,13 @@ def summarize(summary, out=sys.stdout):
 
     # Not as readable as printing, but prepping for unittesting
     out.write(
-        "\nValidation Summary\n" +
-        "------------------\n" +
+        f"\nValidation Summary\n"
+        f"------------------\n"
         f"{report_str}\n"
-        "\n" +
-        f"Passed: {passing_count}\n" +
-        f"Failed: {len(summary) - passing_count}\n"
+        f"\n"
+        f"Passed Curation: {passing_count - skipped_count}\n"
+        f"Already Curated: {skipped_count}\n"
+        f"Failed Curation: {len(summary) - passing_count}\n"
     )
 
 
@@ -632,7 +634,7 @@ if __name__ == "__main__":
                 {release['package']: {
                     "version": release['version'],
                     "pass": passed,
-                    "skipped": True,
+                    "skipped": False,
                     "tests": info}
                 }
             )

--- a/curator.py
+++ b/curator.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
 """
-The app registry curator is a tool that scans Quay.io app registries in order to vet operators for use with OSD v4.
+The app registry curator is a tool that scans Quay.io app registries in
+order to vet operators for use with OSD v4.
 """
 
 import argparse
 import base64
+import itertools
 import json
 import logging
 from pathlib import Path
-import tarfile
 import shutil
 import sys
+import tarfile
 import requests
 import yaml
 
@@ -51,8 +53,24 @@ def _quay_headers(authtoken):
 
 
 def _pkg_shortname(package):
-    ''' Strips out the package's namespace and returns its shortname '''
+    """
+    Strips out the package's namespace and returns its shortname.
+    """
     return package.split('/')[1]
+
+
+def _pkg_namespace(package):
+    """
+    Strips out the package name and returns its namespace.
+    """
+    return package.split('/', 1)[0]
+
+
+def _pkg_curated_namespace(package):
+    """
+    Strips out the package name and returns its curated namespace.
+    """
+    return f"curated-{package.split('/', 1)[0]}"
 
 
 def list_operators(namespace):
@@ -68,22 +86,36 @@ def list_operators(namespace):
 def get_release_data(operator):
     """
     Gets all the release versions for an operator package,
-    eg: redhat-operators/codeready-workspaces, and returns a dictionary
-    of release version, package name, and its digests.
+    eg: redhat-operators/codeready-workspaces, and returns a list of
+    dictionaries with release version, package name, and its digests.
     """
-    releases = {}
+    releases = []
     r = requests.get(_url(f"packages/{operator}"))
     if r.ok:
         for release in r.json():
-            releases[str(release['release'])] = {
-                "digest": str(release['content']['digest']),
-                "package": release['package']
-            }
+            releases.append(
+                {
+                    "package": release['package'],
+                    "digest": str(release['content']['digest']),
+                    "version": release['release'],
+                    "namespace": _pkg_namespace(release['package'])
+                }
+            )
     return releases
+
+
+def curated(package, version):
+    """
+    Check for the package in the curated namespace, and return the result.
+    """
+    curated = [i for i in get_release_data(package) if version in i.values()]
+
+    return curated
 
 
 def set_repo_visibility(namespace, package_shortname, oauth_token, public=True,):
     '''Set the visibility of the specified app registry in Quay.'''
+    # NEEDS TEST
     s = requests.sessions.Session()
 
     visibility = "public" if public else "private"
@@ -109,11 +141,22 @@ def get_package_release(release, use_cache):
     """
     Downloads the tarball package for the release.
     """
-    if use_cache:
+    # NEEDS TEST
+    package = release['package']
+    version = release['version']
+    digest = release['digest']
+
+    outfile = Path(f"{package}/{version}/{_pkg_shortname(package)}.tar.gz")
+
+    if use_cache and Path.exists(outfile):
         return
 
-    r = requests.get(_url(f"packages/{release['package']}/blobs/sha256/{digest}"))
-    outfile = Path(f"{release['package']}/{release['version']}/{_pkg_shortname(release['package'])}.tar.gz")
+    r = requests.get(
+        _url(f"packages/{package}/blobs/sha256/{digest}"),
+        stream=True
+    )
+
+    outfile.parent.mkdir(parents=True, exist_ok=True)
 
     try:
         with open(outfile, 'wb') as f:
@@ -127,6 +170,7 @@ def check_package_in_allow_list(package):
     Returns true if the packaged has been listed in the allow list,
     regardless of other heuristics.  Also returns the test name.
     """
+    logging.debug("Checking if package is in the allow list")
     test_name = 'is in allowed list'
     if package in ALLOWED_PACKAGES:
         return test_name, True
@@ -139,6 +183,7 @@ def check_package_in_deny_list(package):
     Returns true if the packaged has been listed in the denly list,
     regardless of other heuristics.  Also returns the test name.
     """
+    logging.debug("Checking if package is in the deny list")
     test_name = 'is in denied list'
     if package in DENIED_PACKAGES:
         return test_name, True
@@ -146,23 +191,28 @@ def check_package_in_deny_list(package):
     return test_name, False
 
 
-def extract_bundle_from_tar_file(tarfile):
+def extract_bundle_from_tar_file(operator_tarfile):
     """
     Extracts the bundle.yaml file from the tar object provides.
     Returns the bundle.yaml object, test name, and result.
     """
+    logging.debug("Extracting bundle.yaml from tarfile")
 
     test_name = 'bundle.yaml must be present'
-    with tarfile.open(tarfile) as t:
+    with tarfile.open(operator_tarfile) as t:
         try:
-            bundle_file = t.extractfile([i for i in t if Path(i.name).name == "bundle.yaml"][0])
-        except:
+            bundle_file = t.extractfile(
+                [i for i in t if Path(i.name).name == "bundle.yaml"][0]
+            ).read()
+            result = True
+        except IndexError:
             bundle_file = None
             result = False
-        else:
-            result = True
-        finally:
-            return bundle_file, test_name, result
+        except TypeError:
+            bundle_file = None
+            result = False
+
+    return bundle_file, test_name, result
 
 
 def load_yaml_from_bundle_object(bundle_yaml_obj):
@@ -170,51 +220,55 @@ def load_yaml_from_bundle_object(bundle_yaml_obj):
     Loads the yaml from the bundle object and returns a failure if
     it is unable to.  Also returns the test name and result.
     """
+    logging.debug("Loading bundle.yaml data")
 
     test_name = 'bundle.yaml must be parsable'
     try:
-        bundle_yaml = yaml.safe_load(bundle_yaml_obj.read())
+        bundle_yaml = yaml.safe_load(bundle_yaml_obj)
     except yaml.YAMLError:
         bundle_yaml = None
         result = False
     else:
         result = True
-    finally:
-        return bundle_yaml, test_name, result
+
+    return bundle_yaml, test_name, result
 
 
-def get_packages_from_bundle(bundle_yaml):
+def get_entry_from_bundle(bundle_yaml, entry):
     """
-    Tests whether or not packages are contained in the bundle.yaml,
-    and returns them if so, and returns the test name and result.
+    Tests whether or not a particular entry is contained in the bundle.yaml,
+    and returns it if so, and returns the test name and result.
     """
+    logging.debug(f"Loading {entry} list from bundle")
 
-    test_name = "bundle must have a package object"
+    test_name = f"bundle must have a {entry} object"
     try:
-        packages = bundle_yaml['data']['packages']
-    except:
-        packages = None
+        data = yaml.safe_load(bundle_yaml['data'][entry])
+    except yaml.YAMLError:
+        data = None
+        result = False
+    except TypeError:
+        data = None
         result = False
     else:
         result = True
-    finally:
-        return packages, test_name, result
+
+    return data, test_name, result
 
 
-def check_clusterserviceversion(package, version, csv):
+def validate_csv(package, version, csv):
     """
-    Checks csv to make sure there are no clusterPermissions,
-    it does not support multi-namespace install mode,
-    and it does not require security context constraints
+    Checks csv for prohibited clusterPermissions,
+    multi-namespace install mode, and security context constraints.
     """
 
     # Aggregates CSV sub-tests, returns dict of results
     # test_name =
     # return [X], test_name, result
 
-    check_csv_for_clusterpermissions()
-    check_csv_for_securitycontextconstraints()
-    check_csv_for_multinamespace_installmode()
+    #check_csv_for_clusterpermissions()
+    #check_csv_for_securitycontextconstraints()
+    #check_csv_for_multinamespace_installmode()
 
     tests = {}
     # Cluster Permissions aren't allowed
@@ -246,138 +300,6 @@ def check_clusterserviceversion(package, version, csv):
     return result, tests
 
 
-def validate_bundle(release):
-    """
-    Review the bundle.yaml for a package to check that it is
-    appropriate for use with OSD.
-    """
-    package = release['package']
-    version = release['version']
-
-    tests = {}
-    csvsByChannel = {}
-    truncatedBundle = False
-    bundle_filename = "bundle.yaml"
-    bundle_file = Path(f"./{package}/{version}/{bundle_filename}")
-
-    logging.info(f"Validating bundle for {package} version {version}")
-
-    shortname = _pkg_shortname(package)
-
-    # Any package in our allow list is valid, regardless of other heuristics
-    name, result = check_package_in_allow_list(package)
-    tests[name] = result
-    logging.info(f"{'[PASS] if result else [FAIL]'} {package} (all versions) {name}")
-
-    if result:
-        return True, tests
-
-
-    # Any package in our deny is invalid; skip further processing
-    name, result = check_package_in_deny_list(package)
-    tests[name] = result
-    logging.info(f"{'[FAIL] if result else [PASS]'} {package} (all versions) {name}")
-
-    if result:
-        return False, tests
-
-
-    # Extract the bundle.yaml file
-    bundle_yaml_object, name, result = extract_bundle_from_tar_file(
-        f"{package}/{version}/{shortname}.tar.gz")
-
-    tests[name] = result
-    logging.info(f"{'[PASS] if result else [FAIL]'} {package} (all versions) {name}")
-
-    # If extracting the bundle fails, no further processing is possible
-    if not result:
-        return False, tests
-
-
-    # Load the yaml from the bundle object to a variable
-    bundle_yaml, name, result = load_yaml_from_bundle_object(bundle_yaml_object)
-    tests[name] = result
-    logging.info(f"{'[PASS] if result else [FAIL]'} {package} (all versions) {name}")
-
-    # If reading the yaml file fails, no further processing is possible
-    if not result:
-        return False, tests
-
-    # Retrieve the package list from the bundle
-    packages, name, result = get_packages_from_bundle(bundle_yaml)
-    tests[name] = result
-    logging.info(f"{'[PASS] if result else [FAIL]'} {package} (all versions) {name}")
-
-
-    # TODO: create function for testing custom resource definitions
-    # name, result = test_custom_resource_definitions(bundle_yaml['data']['customResourceDefinitions'])
-
-    # The package might have multiple channels, loop thru them
-    for channel in packages[0]['channels']:
-        good_csvs = [] # What is this used for?
-
-        # Test the most recent CSV in the channel
-        latest_channel_csv = get_csv_from_name(csvs, channel['currentCSV'])
-        name, csv_test_results = check_clusterserviceversion(latest_channel_csv)
-
-        # META_CODE
-        # if any of the tests in the test result failed, reject the whole thing
-        # if any False in test_results:
-        name, result = check_test_results_for_failures(csv_test_results)
-        tests[name] = result
-        logging.info(f"{'[PASS] if result else [FAIL]'} {package} (all versions) {name}")
-
-        # Add CSV test results to overall test results
-        tests.update(csv_test_results)
-
-
-        # TODO: REPLICATE THIS
-        # there are channels in each package "package[0]['channels']"
-        # for each channel:
-        # get the latestCSVname: channel['currentCSV']
-        # use the name to get the csv (get_csv_from_name(csvs, latestCSVname))
-        # test the clusterserviceversion of the latet csv
-        # if the latest csv doesnt pass
-        # reject entire thing (return false, tests)
-        # else "latestBundleKey" test is a pass - add to test lists
-        #    good_csvs.append(latestCSV)
-        #latestBundleKey = f"CSV {latestCSV['metadata']['name']} curated"
-        #
-        # Next, tests "latestCSV['spec'].get('replaces)"
-        # (if not 'None')
-        # if not passes, truncate bundle using list of good csvs
-        # and break
-        # else:
-        #        good_csvs.append(nextCSV)
-        #        nextCSVPassKey = f"CSV {replacesCSVName} curated"
-        #        get next csv from 'replaces'
-        #        nextCSV = get_csv_from_name(csvs, replacesCSVName)
-        #        replacesCSVName = nextCSV.get('replaces')
-        # Last:  add good_csvs list to
-        #        csvsByChannel[channel['name']] = good_csvs
-
-        # If the bundle was truncated we need to regen the bundle file and links
-        if truncatedBundle:
-            logging.warning(f"{package} version {version} - writing truncated bundle to tarfile")
-            by = regenerate_bundle_yaml(
-                by,
-                packages,
-                customResourceDefinitions,
-                csvsByChannel)
-
-            with open(bundle_file, 'w') as outfile:
-                yaml.dump(by, outfile, default_style='|')
-
-            # Create tar.gz file, forcing the bundle file to sit in the root of the tar vol
-            with tarfile.open(f"{package}/{version}/{shortname}.tar.gz", "w:gz") as tar_handle:
-                tar_handle.add(bundle_file, arcname=bundle_filename)
-
-    # If all of the values for dict "tests" are True, return True
-    # otherwise return False (operator validation has failed!)
-    result = bool(all(tests.values()))
-    return result, tests
-
-
 def regenerate_bundle_yaml(bundle_yaml, packages,
                            customResourceDefinitions, csvsByChannel):
     """
@@ -399,6 +321,161 @@ def regenerate_bundle_yaml(bundle_yaml, packages,
     return bundle_yaml
 
 
+def validate_bundle(release):
+    """
+    Review the bundle.yaml for a package to check that it is
+    appropriate for use with OSD.
+    """
+    package = release['package']
+    version = release['version']
+    shortname = _pkg_shortname(package)
+
+    tar_file = Path(f"{package}/{version}/{shortname}.tar.gz")
+    bundle_filename = "bundle.yaml"
+    bundle_file = Path(f"./{package}/{version}/{bundle_filename}")
+
+    tests = {}
+    csvsByChannel = {}
+    truncatedBundle = False
+
+    logging.info(f"Validating bundle for {package} version {version}")
+
+
+    # Any package in our allow list is valid, regardless of other heuristics
+    name, result = check_package_in_allow_list(package)
+
+    if result:
+        logging.info(f"[PASS] {package} (all versions) {name}")
+        # ONLY return test result if it is in the list
+        tests[name] = result
+        return True, tests
+
+    # Any package in our deny is invalid; skip further processing
+    name, result = check_package_in_deny_list(package)
+
+    if result:
+        logging.info(f"[FAIL] {package} (all versions) {name}")
+        # ONLY return test result if it is in the list
+        tests[name] = result
+        return False, tests
+
+    # Extract the bundle.yaml file
+    bundle_yaml_object, name, result = extract_bundle_from_tar_file(tar_file)
+
+    tests[name] = result
+    logging.info(f"{'[PASS]' if result else '[FAIL]'} {package} (all versions) {name}")
+
+    # If extracting the bundle fails, no further processing is possible
+    if not result:
+        return False, tests
+
+    # Load the yaml from the bundle object to a variable
+    bundle_yaml, name, result = load_yaml_from_bundle_object(bundle_yaml_object)
+    tests[name] = result
+    logging.info(f"{'[PASS]' if result else '[FAIL]'} {package} (all versions) {name}")
+
+    # If reading the yaml file fails, no further processing is possible
+    if not result:
+        return False, tests
+
+    # Retrieve the package list from the bundle
+    packages, name, result = get_entry_from_bundle(
+        bundle_yaml, 'packages')
+    tests[name] = result
+    logging.info(f"{'[PASS]' if result else '[FAIL]'} {package} (all versions) {name}")
+
+    # If packages didn't exist in the bundle file, no further processing is possible
+    if not result:
+        return False, tests
+
+    # Retrieve the csv list from the bundle
+    csvs, name, result = get_entry_from_bundle(
+        bundle_yaml, 'clusterServiceVersions')
+    tests[name] = result
+    logging.info(f"{'[PASS]' if result else '[FAIL]'} {package} (all versions) {name}")
+
+    # If csvs didn't exist in the bundle file, no further processing is possible
+    if not result:
+        return False, tests
+
+    # Retrieve any CRDs from the bundle; not a test
+    customResourceDefinitions, _, _ = get_entry_from_bundle(
+        bundle_yaml,
+        "customResourceDefinitions"
+    )
+
+    # The rest of this function needs to be refactord into
+    # smaller, simpler functions, and have tests added
+
+    # The package might have multiple channels, loop thru them
+    logging.debug("Validating individual channels in package")
+    for channel in packages[0]['channels']:
+        logging.debug(f"Validating channel {channel['name']}")
+
+        goodCSVs = []
+        channelKey = f"Curated channel: {channel['name']}"
+        tests[channelKey] = False
+        latestCSVname = channel['currentCSV']
+        latestCSV = get_csv_from_name(csvs, latestCSVname)
+        valPass, latestCSVTests = validate_csv(package,
+                                               version,
+                                               latestCSV)
+        latestCSVkey = "The most recent CSV must pass curation"
+        latestCSVTests[latestCSVkey] = True
+
+        # Latest CSV was rejected, we reject the entire bundle
+        if not valPass:
+            latestCSVTests[latestCSVkey] = False
+            return valPass, latestCSVTests
+
+        latestBundleKey = f"CSV {latestCSV['metadata']['name']} curated"
+        tests[latestBundleKey] = True
+
+        goodCSVs.append(latestCSV)
+
+        replacesCSVName = latestCSV['spec'].get('replaces')
+        while replacesCSVName:
+            nextCSV = get_csv_from_name(csvs, replacesCSVName)
+            nextCSVPass, _ = validate_csv(package, version, nextCSV)
+
+            if nextCSVPass:
+                goodCSVs.append(nextCSV)
+                nextCSVPassKey = f"CSV {replacesCSVName} curated"
+                tests[nextCSVPassKey] = True
+                # Refresh the pointer to the 'replaces' tag
+                replacesCSVName = nextCSV.get('replaces')
+            else:
+                # If this CSV does not pass curation, we truncate the bundle
+                # But we do not reject the entire bundle
+                nextCSVRejKey = f"CSV {replacesCSVName} rejected, truncating bundle here"
+                tests[nextCSVRejKey] = True
+                truncatedBundle = True
+                break
+
+        csvsByChannel[channel['name']] = goodCSVs
+        tests[channelKey] = True
+
+    # If the bundle was truncated we need to regen the bundle file and links
+    if truncatedBundle:
+        replacement_bundle_yaml = regenerate_bundle_yaml(
+            bundle_yaml,
+            packages,
+            customResourceDefinitions,
+            csvsByChannel)
+
+        with open(bundle_file, 'w') as outfile:
+            yaml.dump(replacement_bundle_yaml, outfile, default_style='|')
+
+        # Create tar.gz file, forcing the bundle file to sit in the root of the tar vol
+        with tarfile.open(tar_file, "w:gz") as tar_handle:
+            tar_handle.add(bundle_file, arcname=bundle_filename)
+
+    # If all of the values for dict "tests" are True, return True
+    # otherwise return False (operator validation has failed!)
+    result = bool(all(tests.values()))
+    return result, tests
+
+
 def get_csv_from_name(csvs, csvName):
     """
     Returns a cluster service version from the csv name
@@ -410,21 +487,14 @@ def get_csv_from_name(csvs, csvName):
     return None
 
 
-def push_package(package, version, target_namespace, oauth_token, basic_token, skip_push):
+def push_package(release, target_namespace, oauth_token, basic_token):
     '''
     Push package on disk into a target quay namespace.
     '''
+    package = release['package']
+    version = release['version']
+
     shortname = _pkg_shortname(package)
-
-    if skip_push:
-        logging.debug(f"Not pushing package {shortname} to namespace {target_namespace}")
-        return
-
-    # Don't try to push if the specific package version is already present in our target namespace
-    target_releases = get_package_releases(f"{target_namespace}/{shortname}")
-    if version in target_releases.keys():
-        logging.info(f"Version {version} of {shortname} is already present in {target_namespace} namespace. Skipping...")
-        return
 
     with open(f"{package}/{version}/{shortname}.tar.gz") as f:
         encoded_bundle = base64.b64encode(f.read())
@@ -449,15 +519,14 @@ def push_package(package, version, target_namespace, oauth_token, basic_token, s
     except requests.exceptions.Timeout as errt:
         logging.error(f"Failed to upload {shortname} to {target_namespace} namespace. Timeout Error: {errt}")
 
-    # If this is a new package namespace, make it publicly visible
-    if target_releases.keys():
-        set_repo_visibility(target_namespace, shortname, oauth_token)
+    # This is a new package namespace, make it publicly visible
+    set_repo_visibility(target_namespace, shortname, oauth_token)
 
 
 def summarize(summary, out=sys.stdout):
     """Summarize prints a summary of results for human readability."""
 
-    if not type(summary) == list:
+    if not isinstance(summary, list):
         raise TypeError()
     if not summary:
         raise IndexError()
@@ -466,6 +535,7 @@ def summarize(summary, out=sys.stdout):
     report = []
 
     passing_count = len([i for i in summary if {key:value for (key, value) in i.items() if value["pass"]}])
+    skipped_count = len([i for i in summary if {key:value for (key, value) in i.items() if value["skipped"]}])
     for i in summary:
         for operator, info in i.items():
             operator_result = "[PASS]" if info["pass"] else "[FAIL]"
@@ -478,44 +548,108 @@ def summarize(summary, out=sys.stdout):
 
     # Not as readable as printing, but prepping for unittesting
     out.write(
-        "\nValidation Summary\n" +
-        "------------------\n" +
+        f"\nValidation Summary\n"
+        f"------------------\n"
         f"{report_str}\n"
-        "\n" +
-        f"Passed: {passing_count}\n" +
-        f"Failed: {len(summary) - passing_count}\n"
+        f"\n"
+        f"Passed Curation: {passing_count - skipped_count}\n"
+        f"Already Curated: {skipped_count}\n"
+        f"Failed Curation: {len(summary) - passing_count}\n"
     )
 
 
 if __name__ == "__main__":
 
-    PARSER = argparse.ArgumentParser(description="A tool for curating application registry for use with OSDv4")
-    PARSER.add_argument('--app-token', action="store", dest="basic_token",
-                        type=str, help="Basic auth token for use with Quay's CNR API")
-    PARSER.add_argument('--oauth-token', action="store", dest="oauth_token",
-                        type=str, help="Oauth token for use with Quay's repository API")
-    PARSER.add_argument('--cache', action="store_true", default=False, dest="use_cache",
-                        help="Use local cache of operator packages")
-    PARSER.add_argument('--skip-push', action="store_true", default=False, dest="skip_push",
-                        help="Skip pushing validated packages to Quay.io")
-
+    PARSER = argparse.ArgumentParser(
+        description=("""A tool for curating application registry for
+            use with OSDv4."""))
+    PARSER.add_argument(
+        '--app-token', action="store",
+        dest="basic_token", type=str,
+        help="Basic auth token for use with Quay's CNR API")
+    PARSER.add_argument(
+        '--oauth-token', action="store",
+        dest="oauth_token", type=str,
+        help="Oauth token for use with Quay's repository API")
+    PARSER.add_argument(
+        '--cache', action="store_true",
+        default=False, dest="use_cache",
+        help="Use local cache of operator packages")
+    PARSER.add_argument(
+        '--skip-push', action="store_true",
+        default=False, dest="skip_push",
+        help="Skip pushing validated packages to Quay.io")
+    PARSER.add_argument(
+        '--log-level', action="store",
+        default='info', dest="log_level", type=str,
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        help="Set verbosity of logs printed to STDOUT.")
     ARGS = PARSER.parse_args()
 
-    logging.basicConfig(level=logging.INFO)
+    LOGLEVEL = getattr(logging, ARGS.log_level.upper(), None)
+    logging.basicConfig(level=LOGLEVEL)
 
     SUMMARY = []
 
-    for ns in SOURCE_NAMESPACES:
-        for operator in list_operators(ns):
-            release_data = get_release_data(operator)
-            for release in release_data:
-                get_package_release(release, ARGS.use_cache)
-                passed, info = validate_bundle(release)
-                SUMMARY.append({operator: {"version": release_version, "pass": passed, "tests": info}})
-                if passed:
-                    logging.info(f"{operator} version {release_version} is a valid operator for use with OSD")
-                    push_package(operator, release_version, f"curated-{ns}", ARGS.oauth_token, ARGS.basic_token, ARGS.skip_push)
-                else:
-                    logging.info(f"{operator} version {release_version} FAILED VALIDATION for use with OSD")
+    logging.info("Downloading operator data from source namespaces.")
+    OPERATORS = [list_operators(ns) for ns in SOURCE_NAMESPACES]
+
+    logging.info("Downloading release data for operators.")
+    RELEASES = [
+        get_release_data(o) for o in list(itertools.chain(*OPERATORS))
+    ]
+
+    logging.info("Beginning validation testing of release versions.")
+    for release in list(itertools.chain(*RELEASES)):
+
+        shortname = _pkg_shortname(release['package'])
+        version = release['version']
+        namespace = _pkg_namespace(release['package'])
+        curated_namespace = _pkg_curated_namespace(release['package'])
+        curated_package_name = f"{curated_namespace}/{shortname}"
+
+        get_package_release(release, ARGS.use_cache)
+
+        # Don't try to push if the specific package version is already
+        # present in our target namespace
+        if curated(curated_package_name, version):
+            curated_message = (
+                f"[SKIP] {curated_package_name} "
+                f"version {version} already curated"
+            )
+            SUMMARY.append(
+                {
+                    release['package']: {
+                        "version": version,
+                        "pass": True,
+                        "skipped": True,
+                        "tests": {curated_message: True}
+                    }
+                }
+            )
+            logging.info(f"{curated_message}, skipping")
+        else:
+            passed, info = validate_bundle(release)
+            SUMMARY.append(
+                {release['package']: {
+                    "version": release['version'],
+                    "pass": passed,
+                    "skipped": False,
+                    "tests": info}
+                }
+            )
+            logging.info(
+                f"{release['package']}:{version} "
+                f"{'PASSED' if passed else 'FAILED'} "
+                f"validation for use with OSD"
+            )
+
+            if passed and not ARGS.skip_push:
+                push_package(
+                    release,
+                    curated_namespace,
+                    ARGS.oauth_token,
+                    ARGS.basic_token,
+                )
 
     summarize(SUMMARY)

--- a/curator.py
+++ b/curator.py
@@ -159,6 +159,7 @@ def get_package_release(release, use_cache):
     outfile.parent.mkdir(parents=True, exist_ok=True)
 
     try:
+        outfile.parent.mkdir(parents=True, exist_ok=True)
         with open(outfile, 'wb') as f:
             shutil.copyfileobj(r.raw, f)
     finally:

--- a/curator.py
+++ b/curator.py
@@ -315,6 +315,11 @@ def validate_bundle(release):
     ####################################################################
     ### TODO: This bit here needs to be refactored and have tests added
     ####################################################################
+    # Load array of CSVs
+    csvs = bundle_yaml['data']['clusterServiceVersions']
+    # Lodd array of CRDs
+    customResourceDefinitions = bundle_yaml['data']['customResourceDefinitions']
+
     # The package might have multiple channels, loop thru them
     for channel in packages[0]['channels']:
         goodCSVs = []

--- a/curator.py
+++ b/curator.py
@@ -34,11 +34,14 @@ DENIED_PACKAGES = [
     "community-operators/syndesis"
 ]
 
+
 def _url(path):
     return "https://quay.io/cnr/api/v1/" + path
 
+
 def _repo_url(path):
     return "https://quay.io/api/v1/" + path
+
 
 def _quay_headers(authtoken):
     return {
@@ -46,9 +49,21 @@ def _quay_headers(authtoken):
         "Content-Type": "application/json"
     }
 
+
 def _pkg_shortname(package):
     ''' Strips out the package's namespace and returns its shortname '''
     return package.split('/')[1]
+
+
+def list_operators(namespace):
+    '''List the operators in the provided quay app registry namespace'''
+    r = requests.get(_url(f"packages?namespace={namespace}"))
+    if r.ok:
+        l = [str(e['name']) for e in r.json()]
+        return l
+
+    return None
+
 
 def get_package_releases(package):
     '''Returns a dictionary with each version and digest available for a package'''
@@ -59,11 +74,6 @@ def get_package_releases(package):
             releases[str(release['release'])] = str(release['content']['digest'])
     return releases
 
-def list_operators(namespace):
-    '''List the operators in the provided quay app registry namespace'''
-    r = requests.get(_url(f"packages?namespace={namespace}"))
-    l = [str(e['name']) for e in r.json()]
-    return l
 
 def set_repo_visibility(namespace, package_shortname, oauth_token, public=True,):
     '''Set the visibility of the specified app registry in Quay.'''
@@ -86,6 +96,7 @@ def set_repo_visibility(namespace, package_shortname, oauth_token, public=True,)
         logging.error(f"Failed to set visibility of {namespace}/{package_shortname}. Connection Error: {errc}")
     except requests.exceptions.Timeout as errt:
         logging.error(f"Failed to set visibility of {namespace}/{package_shortname}. Timeout Error: {errt}")
+
 
 def retrieve_package(package, version, use_cache):
     '''Downloads an operator's package from quay'''

--- a/curator.py
+++ b/curator.py
@@ -212,7 +212,7 @@ def extract_bundle_from_tar_file(operator_tarfile):
             bundle_file = None
             result = False
 
-    return bundle_file, test_name, result
+    return bundle_file, test_name, True
 
 
 def load_yaml_from_bundle_object(bundle_yaml_obj):

--- a/curator.py
+++ b/curator.py
@@ -159,7 +159,6 @@ def get_package_release(release, use_cache):
     outfile.parent.mkdir(parents=True, exist_ok=True)
 
     try:
-        outfile.parent.mkdir(parents=True, exist_ok=True)
         with open(outfile, 'wb') as f:
             shutil.copyfileobj(r.raw, f)
     finally:

--- a/curator.py
+++ b/curator.py
@@ -212,7 +212,7 @@ def extract_bundle_from_tar_file(operator_tarfile):
             bundle_file = None
             result = False
 
-    return bundle_file, test_name, True
+    return bundle_file, test_name, result
 
 
 def load_yaml_from_bundle_object(bundle_yaml_obj):

--- a/curator.py
+++ b/curator.py
@@ -525,19 +525,30 @@ def summarize(summary, out=sys.stdout):
 
 if __name__ == "__main__":
 
-    PARSER = argparse.ArgumentParser(description="A tool for curating application registry for use with OSDv4")
-    PARSER.add_argument('--app-token', action="store", dest="basic_token",
-                        type=str, help="Basic auth token for use with Quay's CNR API")
-    PARSER.add_argument('--oauth-token', action="store", dest="oauth_token",
-                        type=str, help="Oauth token for use with Quay's repository API")
-    PARSER.add_argument('--cache', action="store_true", default=False, dest="use_cache",
-                        help="Use local cache of operator packages")
-    PARSER.add_argument('--skip-push', action="store_true", default=False, dest="skip_push",
-                        help="Skip pushing validated packages to Quay.io")
-
+    PARSER = argparse.ArgumentParser(
+        description="""
+            A tool for curating application registry for use with OSDv4
+        """)
+    PARSER.add_argument('--app-token', action="store",
+        dest="basic_token", type=str,
+        help="Basic auth token for use with Quay's CNR API")
+    PARSER.add_argument('--oauth-token', action="store",
+        dest="oauth_token", type=str,
+        help="Oauth token for use with Quay's repository API")
+    PARSER.add_argument('--cache', action="store_true",
+        default=False, dest="use_cache", type=str,
+        help="Use local cache of operator packages")
+    PARSER.add_argument('--skip-push', action="store_true",
+        default=False, dest="skip_push", type=str,
+        help="Skip pushing validated packages to Quay.io")
+    PARSER.add_argument('--log-level', action="store",
+        default='info', dest="log_level", type=str,
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        help="Set verbosity of logs printed to STDOUT.")
     ARGS = PARSER.parse_args()
 
-    logging.basicConfig(level=logging.INFO)
+    loglevel = getattr(logging, ARGS.log_level.upper(), None)
+    logging.basicConfig(level=loglevel)
 
     SUMMARY = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+astroid==2.3.2
+certifi==2019.9.11
+chardet==3.0.4
+idna==2.8
+isort==4.3.21
+lazy-object-proxy==1.4.3
+mccabe==0.6.1
+PyYAML==5.1.2
+requests==2.22.0
+six==1.12.0
+typed-ast==1.4.0
+urllib3==1.25.6
+wrapt==1.11.2

--- a/test_curator.py
+++ b/test_curator.py
@@ -50,6 +50,79 @@ class TestRequests(unittest.TestCase):
         self.assertDictEqual(response, expected)
 
 
+    # Not sure how to test this
+    # def test_retrieve_package(self, mock_get):
+
+
+@patch('curator.ALLOWED_PACKAGES',
+    ["wonka-industries/gobstopper-firmware",
+     "stark-industries/jarvis"]
+)
+@patch('curator.DENIED_PACKAGES',
+    ["skynet/find-john-connor",
+     "spacely-sprockets/red-button-input"]
+)
+class TestBundleValidation(unittest.TestCase):
+    # The validate_bundle function need to be WAY shorter and more specific!
+    # Break it up into smaller pieces!
+    # def test_validate_bundle(self):
+
+    def test_check_package_in_allow_list_true(self):
+        package = "stark-industries/jarvis"
+        name, result = curator.check_package_in_allow_list(package)
+
+        self.assertEqual(name, 'is in allowed list')
+        self.assertTrue(result)
+
+
+    def test_check_package_in_allow_list_false(self):
+        package = "skynet/find-john-connor"
+        name, result = curator.check_package_in_allow_list(package)
+
+        self.assertEqual(name, 'is in allowed list')
+        self.assertFalse(result)
+
+
+    def test_check_package_in_deny_list_true(self):
+        package = "skynet/find-john-connor"
+        name, result = curator.check_package_in_deny_list(package)
+
+        self.assertEqual(name, 'is in denied list')
+        self.assertTrue(result)
+
+
+    def test_check_package_in_deny_list_false(self):
+        package = "start-industries/jarvis"
+        name, result = curator.check_package_in_deny_list(package)
+
+        self.assertEqual(name, 'is in denied list')
+        self.assertFalse(result)
+
+    # Not sure how to test this
+    # def extract_bundle_from_tar_file(self):
+
+    # Not sure how to test this
+    # Input is an io.BufferedReader object from the tarfile.extractfile()
+    # def load_yaml_from_bundle_object
+
+#    def test_get_packages_from_bundle_true(self):
+#        bundle_yaml = ""
+#        packages, name, result = curator.get_packages_from_bundle(bundle_yaml)
+#
+#        self.assertIsNotNone(packages)
+#        self.assertEqual(name, 'bundle must have a package object')
+#        self.assertTrue(result)
+#
+
+    def test_get_packages_from_bundle_false(self):
+        bundle_yaml = ""
+        packages, name, result = curator.get_packages_from_bundle(bundle_yaml)
+
+        self.assertIsNone(packages)
+        self.assertEqual(name, 'bundle must have a package object')
+        self.assertFalse(result)
+
+
 class TestPrintingSummary(unittest.TestCase):
     def test_summary_no_results(self):
         summary = []

--- a/test_curator.py
+++ b/test_curator.py
@@ -1,0 +1,170 @@
+import unittest
+import curator
+from io import StringIO
+import requests
+from unittest.mock import Mock, patch
+
+
+class TestStringFormattingHelpers(unittest.TestCase):
+    def test_url(self):
+        self.assertEqual(curator._url("some/url/path"),
+                         "https://quay.io/cnr/api/v1/some/url/path")
+
+
+    def test_repo_url(self):
+        self.assertEqual(curator._repo_url("some/url/path"),
+                         "https://quay.io/api/v1/some/url/path")
+
+
+    def test_quay_headers(self):
+         self.assertEqual(curator._quay_headers("someAuthToken"),
+            {'Authorization': 'someAuthToken', 'Content-Type': 'application/json'}
+        )
+
+    def test_pkg_shortname(self):
+        self.assertEqual(curator._pkg_shortname("some-namespace/some-package"),
+                         "some-package")
+
+
+@patch('curator.requests.get')
+class TestRequests(unittest.TestCase):
+    def test_list_operators(self, mock_get):
+        expected = ['redhat-operators/nfd', 'redhat-operators/metering-ocp']
+        json_response = [{'channels': None, 'created_at': '2019-10-16T20:37:35', 'default': '1.0.0', 'manifests': ['helm'], 'name': 'redhat-operators/nfd', 'namespace': 'redhat-operators', 'releases': ['1.0.0'], 'updated_at': '2019-10-16T20:37:35', 'visibility': 'public'}, {'channels': None, 'created_at': '2019-10-16T20:37:49', 'default': '1.0.0', 'manifests': ['helm'], 'name': 'redhat-operators/metering-ocp', 'namespace': 'redhat-operators', 'releases': ['1.0.0'], 'updated_at': '2019-10-16T20:37:49', 'visibility': 'public'}]
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = json_response
+
+        response = curator.list_operators("redhat-operators")
+
+        self.assertListEqual(response, expected)
+
+
+    def test_get_package_release(self, mock_get):
+        expected =  {'1.0.0': '95b49e2966a8f941d6608bb1ff95ec0e17bdfebcb46a844e7f0205f2972d2824'}
+        json_response = [{'content': {'digest': '95b49e2966a8f941d6608bb1ff95ec0e17bdfebcb46a844e7f0205f2972d2824', 'mediaType': 'application/vnd.cnr.package.helm.v0.tar+gzip', 'size': 13140, 'urls': []}, 'created_at': '2019-10-16T20:37:35', 'digest': 'sha256:8a752a4887c42d4d1f7059d3a510db2a3f900325ced7b4cbb7a77d0fbf7cbfda', 'mediaType': 'application/vnd.cnr.package-manifest.helm.v0.json', 'metadata': None, 'package': 'redhat-operators/nfd', 'release': '1.0.0'}]
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = json_response
+
+        response = curator.get_package_releases('nfd')
+
+        self.assertDictEqual(response, expected)
+
+
+class TestPrintingSummary(unittest.TestCase):
+    def test_summary_no_results(self):
+        summary = []
+        with self.assertRaises(IndexError):
+            curator.summarize(summary)
+
+
+    def test_summary_is_list(self):
+        summary = {}
+        with self.assertRaises(TypeError):
+            curator.summarize(summary)
+
+
+    def test_summary_single_element(self):
+        summary = [
+            {"testOperator0":
+                {"version": "1.0.0",
+                 "pass": False,
+                 "tests":
+                     {"is in allowed list": False}
+                }
+            }
+        ]
+
+        expected_output = (
+            "Validation Summary\n" +
+            "------------------\n" +
+            "\n" +
+            "[FAIL] testOperator0 version 1.0.0\n" +
+            "    [FAIL] is in allowed list\n" +
+            "\n" +
+            "Passed: 0\n" +
+            "Failed: 1"
+        )
+
+        out=StringIO()
+        curator.summarize(summary, out=out)
+        output = out.getvalue().strip()
+        self.assertEqual(output, expected_output)
+
+
+    def test_summary_no_passes(self):
+        summary = [
+            {"testOperator0":
+                {"version": "1.0.0",
+                 "pass": False,
+                 "tests":
+                     {"is in allowed list": False}
+                }
+            },
+            {"testOperator1":
+                {"version": "2.2.40",
+                 "pass": False,
+                 "tests":
+                     {"is in allowed list": False}
+                }
+            }
+        ]
+
+        expected_output = (
+            "Validation Summary\n" +
+            "------------------\n" +
+            "\n" +
+            "[FAIL] testOperator0 version 1.0.0\n" +
+            "    [FAIL] is in allowed list\n" +
+            "\n" +
+            "[FAIL] testOperator1 version 2.2.40\n" +
+            "    [FAIL] is in allowed list\n" +
+            "\n" +
+            "Passed: 0\n" +
+            "Failed: 2"
+        )
+
+        out=StringIO()
+        curator.summarize(summary, out=out)
+        output = out.getvalue().strip()
+        self.assertEqual(output, expected_output)
+
+
+    def test_summary_output(self):
+        summary = [
+            {"testOperator0":
+                {"version": "1.0.0",
+                 "pass": True,
+                 "tests":
+                     {"is in allowed list": True}
+                }
+            },
+            {"testOperator1":
+                {"version": "2.2.40",
+                 "pass": True,
+                 "tests":
+                     {"is in allowed list": True}
+                }
+            }
+        ]
+
+        expected_output = (
+            "Validation Summary\n" +
+            "------------------\n" +
+            "\n" +
+            "[PASS] testOperator0 version 1.0.0\n" +
+            "    [PASS] is in allowed list\n" +
+            "\n" +
+            "[PASS] testOperator1 version 2.2.40\n" +
+            "    [PASS] is in allowed list\n" +
+            "\n" +
+            "Passed: 2\n" +
+            "Failed: 0"
+        )
+
+        out=StringIO()
+        curator.summarize(summary, out=out)
+        output = out.getvalue().strip()
+        self.assertEqual(output, expected_output)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_curator.py
+++ b/test_curator.py
@@ -19,19 +19,61 @@ class TestStringFormattingHelpers(unittest.TestCase):
 
     def test_quay_headers(self):
          self.assertEqual(curator._quay_headers("someAuthToken"),
-            {'Authorization': 'someAuthToken', 'Content-Type': 'application/json'}
+            {
+                'Authorization': 'someAuthToken',
+                'Content-Type': 'application/json'
+            }
         )
 
     def test_pkg_shortname(self):
-        self.assertEqual(curator._pkg_shortname("some-namespace/some-package"),
-                         "some-package")
+        self.assertEqual(
+            curator._pkg_shortname("some-namespace/some-package"),
+            "some-package"
+        )
+
+    def test_pkg_namespace(self):
+        self.assertEqual(
+            curator._pkg_namespace("some-namespace/some-package"),
+            "some-namespace"
+        )
+
+    def test_pkg_curated_namespace(self):
+        self.assertEqual(
+            curator._pkg_curated_namespace(
+                "some-namespace/some-package"
+            ),
+            "curated-some-namespace"
+        )
 
 
 @patch('curator.requests.get')
 class TestRequests(unittest.TestCase):
     def test_list_operators(self, mock_get):
         expected = ['redhat-operators/nfd', 'redhat-operators/metering-ocp']
-        json_response = [{'channels': None, 'created_at': '2019-10-16T20:37:35', 'default': '1.0.0', 'manifests': ['helm'], 'name': 'redhat-operators/nfd', 'namespace': 'redhat-operators', 'releases': ['1.0.0'], 'updated_at': '2019-10-16T20:37:35', 'visibility': 'public'}, {'channels': None, 'created_at': '2019-10-16T20:37:49', 'default': '1.0.0', 'manifests': ['helm'], 'name': 'redhat-operators/metering-ocp', 'namespace': 'redhat-operators', 'releases': ['1.0.0'], 'updated_at': '2019-10-16T20:37:49', 'visibility': 'public'}]
+        json_response = [
+            {
+                'channels': None,
+                'created_at': '2019-10-16T20:37:35',
+                'default': '1.0.0',
+                'manifests': ['helm'],
+                'name': 'redhat-operators/nfd',
+                'namespace': 'redhat-operators',
+                'releases': ['1.0.0'],
+                'updated_at': '2019-10-16T20:37:35',
+                'visibility': 'public'
+            },
+            {
+                'channels': None,
+                'created_at': '2019-10-16T20:37:49',
+                'default': '1.0.0',
+                'manifests': ['helm'],
+                'name': 'redhat-operators/metering-ocp',
+                'namespace': 'redhat-operators',
+                'releases': ['1.0.0'],
+                'updated_at': '2019-10-16T20:37:49',
+                'visibility': 'public'
+            }
+        ]
         mock_get.return_value.ok = True
         mock_get.return_value.json.return_value = json_response
 
@@ -41,12 +83,34 @@ class TestRequests(unittest.TestCase):
 
 
     def test_get_release_data(self, mock_get):
-        expected = [{'package': 'redhat-operators/nfd', 'digest': '95b49e2966a8f941d6608bb1ff95ec0e17bdfebcb46a844e7f0205f2972d2824', 'version': '1.0.0'}]
-        json_response = [{'content': {'digest': '95b49e2966a8f941d6608bb1ff95ec0e17bdfebcb46a844e7f0205f2972d2824', 'mediaType': 'application/vnd.cnr.package.helm.v0.tar+gzip', 'size': 13140, 'urls': []}, 'created_at': '2019-10-16T20:37:35', 'digest': 'sha256:8a752a4887c42d4d1f7059d3a510db2a3f900325ced7b4cbb7a77d0fbf7cbfda', 'mediaType': 'application/vnd.cnr.package-manifest.helm.v0.json', 'metadata': None, 'package': 'redhat-operators/nfd', 'release': '1.0.0'}]
+        expected = [
+            {
+                'package': 'redhat-operators/nfd',
+                'digest': '95b49e2966a8f941d6608bb1ff95ec0e17bdfebcb46a844e7f0205f2972d2824',
+                'version': '1.0.0',
+                'namespace': 'redhat-operators'
+            }
+        ]
+        json_response = [
+            {
+                'content': {
+                    'digest': '95b49e2966a8f941d6608bb1ff95ec0e17bdfebcb46a844e7f0205f2972d2824',
+                    'mediaType': 'application/vnd.cnr.package.helm.v0.tar+gzip',
+                    'size': 13140,
+                    'urls': []
+                },
+                'created_at': '2019-10-16T20:37:35',
+                'digest': 'sha256:8a752a4887c42d4d1f7059d3a510db2a3f900325ced7b4cbb7a77d0fbf7cbfda',
+                'mediaType': 'application/vnd.cnr.package-manifest.helm.v0.json',
+                'metadata': None,
+                'package': 'redhat-operators/nfd',
+                'release': '1.0.0'
+            }
+        ]
         mock_get.return_value.ok = True
         mock_get.return_value.json.return_value = json_response
 
-        response = curator.get_release_data('nfd')
+        response = curator.get_release_data('redhat-operators/nfd')
 
         self.assertListEqual(response, expected)
 

--- a/test_curator.py
+++ b/test_curator.py
@@ -308,6 +308,7 @@ class TestPrintingSummary(unittest.TestCase):
             {"testOperator0":
                 {"version": "1.0.0",
                  "pass": False,
+                 "skipped": False,
                  "tests":
                      {"is in allowed list": False}
                 }
@@ -321,8 +322,9 @@ class TestPrintingSummary(unittest.TestCase):
             "[FAIL] testOperator0 version 1.0.0\n" +
             "    [FAIL] is in allowed list\n" +
             "\n" +
-            "Passed: 0\n" +
-            "Failed: 1"
+            "Passed Curation: 0\n" +
+            "Already Curated: 0\n" +
+            "Failed Curation: 1"
         )
 
         out=StringIO()
@@ -336,6 +338,7 @@ class TestPrintingSummary(unittest.TestCase):
             {"testOperator0":
                 {"version": "1.0.0",
                  "pass": False,
+                 "skipped": False,
                  "tests":
                      {"is in allowed list": False}
                 }
@@ -343,6 +346,7 @@ class TestPrintingSummary(unittest.TestCase):
             {"testOperator1":
                 {"version": "2.2.40",
                  "pass": False,
+                 "skipped": False,
                  "tests":
                      {"is in allowed list": False}
                 }
@@ -359,8 +363,9 @@ class TestPrintingSummary(unittest.TestCase):
             "[FAIL] testOperator1 version 2.2.40\n" +
             "    [FAIL] is in allowed list\n" +
             "\n" +
-            "Passed: 0\n" +
-            "Failed: 2"
+            "Passed Curation: 0\n" +
+            "Already Curated: 0\n" +
+            "Failed Curation: 2"
         )
 
         out=StringIO()
@@ -374,6 +379,7 @@ class TestPrintingSummary(unittest.TestCase):
             {"testOperator0":
                 {"version": "1.0.0",
                  "pass": True,
+                 "skipped": False,
                  "tests":
                      {"is in allowed list": True}
                 }
@@ -381,6 +387,7 @@ class TestPrintingSummary(unittest.TestCase):
             {"testOperator1":
                 {"version": "2.2.40",
                  "pass": True,
+                 "skipped": True,
                  "tests":
                      {"is in allowed list": True}
                 }
@@ -397,8 +404,9 @@ class TestPrintingSummary(unittest.TestCase):
             "[PASS] testOperator1 version 2.2.40\n" +
             "    [PASS] is in allowed list\n" +
             "\n" +
-            "Passed: 2\n" +
-            "Failed: 0"
+            "Passed Curation: 1\n" +
+            "Already Curated: 1\n" +
+            "Failed Curation: 0"
         )
 
         out=StringIO()

--- a/test_curator.py
+++ b/test_curator.py
@@ -39,13 +39,13 @@ class TestRequests(unittest.TestCase):
         self.assertListEqual(response, expected)
 
 
-    def test_get_package_release(self, mock_get):
+    def test_get_release_data(self, mock_get):
         expected =  {'1.0.0': '95b49e2966a8f941d6608bb1ff95ec0e17bdfebcb46a844e7f0205f2972d2824'}
         json_response = [{'content': {'digest': '95b49e2966a8f941d6608bb1ff95ec0e17bdfebcb46a844e7f0205f2972d2824', 'mediaType': 'application/vnd.cnr.package.helm.v0.tar+gzip', 'size': 13140, 'urls': []}, 'created_at': '2019-10-16T20:37:35', 'digest': 'sha256:8a752a4887c42d4d1f7059d3a510db2a3f900325ced7b4cbb7a77d0fbf7cbfda', 'mediaType': 'application/vnd.cnr.package-manifest.helm.v0.json', 'metadata': None, 'package': 'redhat-operators/nfd', 'release': '1.0.0'}]
         mock_get.return_value.ok = True
         mock_get.return_value.json.return_value = json_response
 
-        response = curator.get_package_releases('nfd')
+        response = curator.get_release_data('nfd')
 
         self.assertDictEqual(response, expected)
 


### PR DESCRIPTION
This PR is a large refactor of the curator code, including:
* added some unit test coverage (not 100%)
* split a lot of functions into smaller ones, so they could be tested more easlily
* standardized the way test reporting works across the script
* multiple pylint fixes
* removes some unnecessary downloads of data from Quay
* moves checking for already-curated operators to the beginning, so we don't waste time checking them
* Adds a Dockerfile for containerized builds