### PR TITLE
Fix report printing errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+# Ignore local cache
 certified-operators/
 community-operators/
 redhat-operators/
 
+# Ignore Pycache
 __pycache__/
+
+# Ignore VS Code settings
+.vscode/

--- a/curator.py
+++ b/curator.py
@@ -171,7 +171,7 @@ def check_package_in_allow_list(package):
     regardless of other heuristics.  Also returns the test name.
     """
     logging.debug("Checking if package is in the allow list")
-    test_name = 'is in allowed list'
+    test_name = 'Package is in allowed list'
     if package in ALLOWED_PACKAGES:
         return test_name, True
 
@@ -184,7 +184,7 @@ def check_package_in_deny_list(package):
     regardless of other heuristics.  Also returns the test name.
     """
     logging.debug("Checking if package is in the deny list")
-    test_name = 'is in denied list'
+    test_name = 'Package is in denied list'
     if package in DENIED_PACKAGES:
         return test_name, True
 
@@ -340,7 +340,6 @@ def validate_bundle(release):
 
     logging.info(f"Validating bundle for {package} version {version}")
 
-
     # Any package in our allow list is valid, regardless of other heuristics
     name, result = check_package_in_allow_list(package)
 
@@ -356,7 +355,9 @@ def validate_bundle(release):
     if result:
         logging.info(f"[FAIL] {package} (all versions) {name}")
         # ONLY return test result if it is in the list
-        tests[name] = result
+        # For this one test, a positive result means it *FAILS*
+        # Send false to the summary, instead of the result
+        tests[name] = False
         return False, tests
 
     # Extract the bundle.yaml file

--- a/curator.py
+++ b/curator.py
@@ -543,7 +543,9 @@ def summarize(summary, out=sys.stdout):
             operator_result = "[PASS]" if info["pass"] else "[FAIL]"
             report.append(f"\n{operator_result} {operator} version {info['version']}")
             for name, result in info["tests"].items():
-                test_result = "[PASS]" if result else "[FAIL]"
+                test_result = (
+                    "[SKIP]" if info["skipped"] else (
+                        "[PASS]" if result else "[FAIL]"))
                 report.append(f"    {test_result} {name}")
 
     report_str = "\n".join(report)
@@ -616,7 +618,7 @@ if __name__ == "__main__":
         # present in our target namespace
         if curated(curated_package_name, version):
             curated_message = (
-                f"[SKIP] {curated_package_name} "
+                f"{curated_package_name} "
                 f"version {version} already curated"
             )
             SUMMARY.append(
@@ -629,7 +631,7 @@ if __name__ == "__main__":
                     }
                 }
             )
-            logging.info(f"{curated_message}, skipping")
+            logging.info(f"[SKIP] {curated_message}")
         else:
             passed, info = validate_bundle(release)
             SUMMARY.append(

--- a/test_curator.py
+++ b/test_curator.py
@@ -136,7 +136,7 @@ class TestBundleValidation(unittest.TestCase):
         package = "stark-industries/jarvis"
         name, result = curator.check_package_in_allow_list(package)
 
-        self.assertEqual(name, 'is in allowed list')
+        self.assertEqual(name, 'Package is in allowed list')
         self.assertTrue(result)
 
 
@@ -144,7 +144,7 @@ class TestBundleValidation(unittest.TestCase):
         package = "skynet/find-john-connor"
         name, result = curator.check_package_in_allow_list(package)
 
-        self.assertEqual(name, 'is in allowed list')
+        self.assertEqual(name, 'Package is in allowed list')
         self.assertFalse(result)
 
 
@@ -152,7 +152,7 @@ class TestBundleValidation(unittest.TestCase):
         package = "skynet/find-john-connor"
         name, result = curator.check_package_in_deny_list(package)
 
-        self.assertEqual(name, 'is in denied list')
+        self.assertEqual(name, 'Package is in denied list')
         self.assertTrue(result)
 
 
@@ -160,7 +160,7 @@ class TestBundleValidation(unittest.TestCase):
         package = "start-industries/jarvis"
         name, result = curator.check_package_in_deny_list(package)
 
-        self.assertEqual(name, 'is in denied list')
+        self.assertEqual(name, 'Package is in denied list')
         self.assertFalse(result)
 
     # def extract_bundle_from_tar_file(self):

--- a/test_curator.py
+++ b/test_curator.py
@@ -389,7 +389,7 @@ class TestPrintingSummary(unittest.TestCase):
                  "pass": True,
                  "skipped": True,
                  "tests":
-                     {"is in allowed list": True}
+                     {"is already curated": True}
                 }
             }
         ]
@@ -402,7 +402,7 @@ class TestPrintingSummary(unittest.TestCase):
             "    [PASS] is in allowed list\n" +
             "\n" +
             "[PASS] testOperator1 version 2.2.40\n" +
-            "    [PASS] is in allowed list\n" +
+            "    [SKIP] is already curated\n" +
             "\n" +
             "Passed Curation: 1\n" +
             "Already Curated: 1\n" +


### PR DESCRIPTION
* Fixes [PASS] on tests where operator is in denied list
* Fixes [PASS] [SKIP] double-result for operators that are already curated
* Made deny/allow messages more human-language
* Add .vscode settings dir to .gitignore